### PR TITLE
Add `csrf/param` and `csrf/token` controller endpoints

### DIFF
--- a/src/controllers/CsrfController.php
+++ b/src/controllers/CsrfController.php
@@ -17,7 +17,7 @@ class CsrfController extends Controller
     /**
      * @inheritdoc
      */
-    protected $allowAnonymous = ['input'];
+    protected $allowAnonymous = ['input', 'value'];
 
     // Public Methods
     // =========================================================================
@@ -38,5 +38,18 @@ class CsrfController extends Controller
         $input = '<input type="hidden" name="'.$generalConfig->csrfTokenName.'" value="'.Craft::$app->getRequest()->getCsrfToken().'">';
 
         return $this->asRaw($input);
+    }
+
+    public function actionValue(): Response
+    {
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        if (!$generalConfig->enableCsrfProtection) {
+            return $this->asRaw('');
+        }
+
+        $value = Craft::$app->getRequest()->getCsrfToken();
+
+        return $this->asRaw($value);
     }
 }

--- a/src/controllers/CsrfController.php
+++ b/src/controllers/CsrfController.php
@@ -17,7 +17,7 @@ class CsrfController extends Controller
     /**
      * @inheritdoc
      */
-    protected $allowAnonymous = ['input', 'value'];
+    protected $allowAnonymous = ['input', 'param', 'token'];
 
     // Public Methods
     // =========================================================================
@@ -40,7 +40,7 @@ class CsrfController extends Controller
         return $this->asRaw($input);
     }
 
-    public function actionValue(): Response
+    public function actionParam(): Response
     {
         $generalConfig = Craft::$app->getConfig()->getGeneral();
 
@@ -48,8 +48,21 @@ class CsrfController extends Controller
             return $this->asRaw('');
         }
 
-        $value = Craft::$app->getRequest()->getCsrfToken();
+        $param = $generalConfig->csrfTokenName;
 
-        return $this->asRaw($value);
+        return $this->asRaw($param);
+    }
+
+    public function actionToken(): Response
+    {
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        if (!$generalConfig->enableCsrfProtection) {
+            return $this->asRaw('');
+        }
+
+        $token = Craft::$app->getRequest()->getCsrfToken();
+
+        return $this->asRaw($token);
     }
 }

--- a/src/services/GenerateCacheService.php
+++ b/src/services/GenerateCacheService.php
@@ -100,7 +100,7 @@ class GenerateCacheService extends Component
         }
 
         // Don't proceed if not a cacheable element type
-        if (!ElementTypeHelper::getIsCacheableElementType($elementQuery->elementType)) {
+        if (empty($elementQuery->elementType) || !ElementTypeHelper::getIsCacheableElementType($elementQuery->elementType)) {
             return;
         }
 


### PR DESCRIPTION
We have `<meta name="csrf-token" content="{{ craft.app.request.csrfToken }}">` in the _layout of most of our sites. In our Vue components, we grab that value whenever we need to make an Ajax request for form submissions, etc. Of course, with Blitz, this token is cached, so no longer useful, and need to use an xhr request to update it, exactly the same way you do with the form input.

This adds some new actions to get just the token and CSRF token name.

With this, we can do:
```
{% js %}    
    var xhr = new XMLHttpRequest();
    xhr.onload = function () {
        if (xhr.status >= 200 && xhr.status < 300) {
            document.head.querySelector('meta[name="csrf-token"]').content = this.responseText;
        }
    };
    xhr.open('GET', '/actions/blitz/csrf/token');
    xhr.send();
{% endjs %}
```