### PR TITLE
Fix potential error if blitz-inject element isn't found

### DIFF
--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -159,7 +159,9 @@ class BlitzVariable
                     var xhr = new XMLHttpRequest();
                     xhr.onload = function () {
                         if (xhr.status >= 200 && xhr.status < 300) {
-                            document.getElementById("blitz-inject-" + id).innerHTML = this.responseText;
+                            if (document.getElementById("blitz-inject-" + id)) {
+                                document.getElementById("blitz-inject-" + id).innerHTML = this.responseText;
+                            }
                         }
                     };
                     xhr.open("GET", uri);


### PR DESCRIPTION
Just a quick fix where this can throw a JS error in some circumstances.