### PR TITLE
Make the dynamic content mechanism work with an XHR page navigation

### DIFF
--- a/src/resources/js/blitzInjectScript.js
+++ b/src/resources/js/blitzInjectScript.js
@@ -1,17 +1,17 @@
-var Blitz = {
-    inject: {
-        data: [],
-        loaded: 0
-    }
-};
-
 // The event will be replaced with the `injectScriptEvent` config setting.
 document.addEventListener("{injectScriptEvent}", blitzInject);
 
 function blitzInject() {
     "use strict";
 
-    var event = new CustomEvent("beforeBlitzInjectAll", {
+    const Blitz = {
+        inject: {
+            data: document.querySelectorAll('.blitz-inject:not(.blitz-inject--injected)'),
+            loaded: 0
+        }
+    };
+
+    const event = new CustomEvent("beforeBlitzInjectAll", {
         cancelable: true
     });
 
@@ -20,10 +20,14 @@ function blitzInject() {
     }
 
     Blitz.inject.data.forEach(function(data, index) {
-        var customEventInit = {
+        const dataUri = data.getAttribute('data-blitz-uri');
+        const dataParams = data.getAttribute('data-blitz-params')
+        const dataId = data.getAttribute('data-blitz-id')
+
+        const customEventInit = {
             detail: {
-                uri: data.uri,
-                params: data.params
+                uri: dataUri,
+                params: dataParams
             },
             cancelable: true
         };
@@ -32,17 +36,17 @@ function blitzInject() {
             return;
         }
 
-        var xhr = new XMLHttpRequest();
-
+        const xhr = new XMLHttpRequest();
         xhr.onload = function() {
             if (xhr.status >= 200 && xhr.status < 300) {
-                var element = document.getElementById("blitz-inject-" + data.id);
+                const element = document.getElementById("blitz-inject-" + dataId);
 
                 if (element) {
                     customEventInit.detail.element = element;
                     customEventInit.detail.responseText = this.responseText;
 
                     element.innerHTML = this.responseText;
+                    element.classList.add('blitz-inject--injected');
                 }
 
                 document.dispatchEvent(new CustomEvent("afterBlitzInject", customEventInit));
@@ -55,7 +59,7 @@ function blitzInject() {
             }
         };
 
-        xhr.open("GET", data.uri + (data.params && "?" + data.params));
+        xhr.open("GET", dataUri + (dataParams && "?" + dataParams));
         xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
         xhr.send();
     });

--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -170,13 +170,10 @@ class BlitzVariable
             }
         }
 
-        $this->_injected++;
-
-        $js .= 'Blitz.inject.data.push({id: '.$this->_injected.', uri: "'.$uri.'", params: "'.http_build_query($params).'"});';
-
         $view->registerJs($js, View::POS_END);
 
-        $output = '<span class="blitz-inject" id="'.'blitz-inject-'.$this->_injected.'"></span>';
+        $id = ++$this->_injected;
+        $output = '<span class="blitz-inject" id="blitz-inject-'.$id.'" data-blitz-id="'.$id.'" data-blitz-uri="'.$uri.'" data-blitz-params="'.http_build_query($params).'"></span>';
 
         return Template::raw($output);
     }


### PR DESCRIPTION
- Prevent Blitz from refreshing elements that should not be updated
- Include Blitz directives directly in the `<span class="blitz-inject">` HTML node
- Re-initialize the Blitz variable each time the `{injectScriptEvent}` event is triggered
- Turned `var` into `const` wherever it made sense

Linked to #179