### PR TITLE
Fixes #199

### DIFF
--- a/src/services/RefreshCacheService.php
+++ b/src/services/RefreshCacheService.php
@@ -471,7 +471,8 @@ class RefreshCacheService extends Component
 
             foreach ($elementExpiryDates as $elementExpiryDate) {
                 /** @var ElementExpiryDateRecord $elementExpiryDate */
-                $element = $elementsService->getElementById($elementExpiryDate->elementId);
+                $elementType = $elementsService->getElementTypeById($elementExpiryDate->elementId);
+                $element = (new $elementType)->find()->id($elementExpiryDate->elementId)->site('*')->one();
 
                 // This should happen before invalidating the element so that other expiry dates will be saved
                 $elementExpiryDate->delete();

--- a/src/services/RefreshCacheService.php
+++ b/src/services/RefreshCacheService.php
@@ -472,7 +472,10 @@ class RefreshCacheService extends Component
             foreach ($elementExpiryDates as $elementExpiryDate) {
                 /** @var ElementExpiryDateRecord $elementExpiryDate */
                 $elementType = $elementsService->getElementTypeById($elementExpiryDate->elementId);
-                $element = (new $elementType)->find()->id($elementExpiryDate->elementId)->site('*')->one();
+
+                if($elementType !== null) {
+                    $element = (new $elementType)->find()->id($elementExpiryDate->elementId)->site('*')->one();
+                }
 
                 // This should happen before invalidating the element so that other expiry dates will be saved
                 $elementExpiryDate->delete();


### PR DESCRIPTION
Not sure about approach. If at this point we can expect the element to be of `Entry` type we can just as easily call `Entry::find()` instead of calling it class name, found trough the elementsservice.