### PR TITLE
Reset cacheIds and elementIds after creating a new refresh job

### DIFF
--- a/src/services/RefreshCacheService.php
+++ b/src/services/RefreshCacheService.php
@@ -399,6 +399,8 @@ class RefreshCacheService extends Component
             // The queue probably doesn't support custom push priorities. Try again without one.
             $queue->push($refreshCacheJob);
         }
+
+        $this->reset();
     }
 
     /**
@@ -539,5 +541,15 @@ class RefreshCacheService extends Component
         $this->addCacheIds($cacheIds);
 
         $this->refresh(true);
+    }
+
+    /**
+     * Reset service to initial state
+     */
+    public function reset()
+    {
+        $this->batchMode = false;
+        $this->cacheIds = [];
+        $this->elements = [];
     }
 }


### PR DESCRIPTION
Fixes #245 

Resetting `RefreshCacheService` to initial state after creating a new `RefreshCacheJob` ensures that repeated calls to `RefreshCacheService::refresh()` won't cause duplicated refresh jobs.