### PR TITLE
Fix the baseUrl replacement for getSiteUriFromUrl

### DIFF
--- a/src/helpers/SiteUriHelper.php
+++ b/src/helpers/SiteUriHelper.php
@@ -242,7 +242,11 @@ class SiteUriHelper
             $baseUrl = trim(Craft::getAlias($site->getBaseUrl()), '/');
 
             if (stripos($url, $baseUrl) === 0) {
-                $uri = str_replace($baseUrl, '', $url);
+                $uri = preg_replace(
+                    '/'.preg_quote($baseUrl, '/').'/',
+                    '',
+                    $url,
+                    1);
                 $uri = trim($uri, '/');
 
                 return new SiteUriModel([


### PR DESCRIPTION
# Problem
If you add the whole URL as part of the path blitz will return a cached site and not a 404 what would be expected.

# Steps to reproduce
1. Open https://www.oekk.ch/en/private-clients to ensure that the page is cached
2. Open https://www.oekk.ch/en/https://www.oekk.ch/en/private-clients 

The returned page is the cached page of https://www.oekk.ch/en/private-clients but it should return
a 404 because there exists no entry with the `en/https://www.oekk.ch/en/private-clients`.

# Explanation:
This ensures that the baseUrl does just get replace once
in the URL for the request. If the path contains the
baseUrl itself it could change the path of the request
and the result would be an unexpected behavior.

In the case of an existing site which is already cached
blitz would return a valid site on a url which should return a 404.
We must ensure that we really only replace the baseUrl and do not
interfere with the path part of the URL.