### PR TITLE
Avoid caching when the query is orderBy FixedOrderExpression

### DIFF
--- a/src/helpers/ElementQueryHelper.php
+++ b/src/helpers/ElementQueryHelper.php
@@ -10,6 +10,7 @@ use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
 use craft\helpers\ArrayHelper;
 use DateTime;
+use craft\db\FixedOrderExpression;
 
 class ElementQueryHelper
 {
@@ -267,6 +268,20 @@ class ElementQueryHelper
         }
 
         return false;
+    }
+
+    /**
+     * Returns whether the element query is order by a FixedOrderExpression
+     *
+     * @param ElementQuery $elementQuery
+     *
+     * @return bool
+     */
+    public static function isOrderByFixedOrderExpression(ElementQuery $elementQuery): bool
+    {
+        $orderBy = $elementQuery->orderBy;
+
+        return $orderBy instanceof FixedOrderExpression;
     }
 
     // Private Methods

--- a/src/services/GenerateCacheService.php
+++ b/src/services/GenerateCacheService.php
@@ -147,6 +147,11 @@ class GenerateCacheService extends Component
             return;
         }
 
+        // Don't proceed if this is a query orderby FixedOrderExpression
+        if (ElementQueryHelper::isOrderByFixedOrderExpression($elementQuery)) {
+            return;
+        }
+
         $this->saveElementQuery($elementQuery);
     }
 


### PR DESCRIPTION
Because caching query involves json encode/decode the orderBy param, if FixedOrderExpression is used, the query cannot be successfully "recovered", throwing an error when clearing the cache.

Added extra check to avoid this from happening.