### PR TITLE
Clear cache without collecting URLs

### DIFF
--- a/src/services/RefreshCacheService.php
+++ b/src/services/RefreshCacheService.php
@@ -476,18 +476,22 @@ class RefreshCacheService extends Component
         if (!$event->isValid) {
             return;
         }
+        
+        $warmCacheAutomatically = Blitz::$plugin->settings->cachingEnabled && Blitz::$plugin->settings->warmCacheAutomatically;
 
         // Get warmable site URIs before flushing the cache
-        $siteUris = array_merge(
-            SiteUriHelper::getAllSiteUris(true),
-            Blitz::$plugin->settings->getCustomSiteUris()
-        );
+        if ($warmCacheAutomatically) {
+            $siteUris = array_merge(
+                SiteUriHelper::getAllSiteUris(true),
+                Blitz::$plugin->settings->getCustomSiteUris()
+            );
+        }
 
         Blitz::$plugin->flushCache->flushAll();
         Blitz::$plugin->clearCache->clearAll();
 
         // Warm and deploy if enabled
-        if (Blitz::$plugin->settings->cachingEnabled && Blitz::$plugin->settings->warmCacheAutomatically) {
+        if ($warmCacheAutomatically) {
             Blitz::$plugin->cacheWarmer->warmUris($siteUris, null, Blitz::$plugin->cachePurger->warmCacheDelay);
 
             Blitz::$plugin->deployer->deployUris($siteUris);


### PR DESCRIPTION
I have a website with a lot of content.
When I save something in SEOmatic, this process takes a very long time because the blitz starts clearing the entire cache, which is quite normal
But I don’t warm it up, and it still collects URLs, which takes a very, very long time due to the large amount of content.
I think this part should be wrapped in a condition so that the URLs are collected only if the cache is warmed up.
If you agree with me, then please do the same for version 4.