### PR TITLE
Update `getUri` deprecation log to suggest `fetchUri` instead of `fetch`

### DIFF
--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -116,7 +116,7 @@ class BlitzVariable
      */
     public function getUri(string $uri, array $params = []): Markup
     {
-        Craft::$app->getDeprecator()->log(__METHOD__, '`craft.blitz.getUri()` has been deprecated. Use `craft.blitz.fetch()` instead.');
+        Craft::$app->getDeprecator()->log(__METHOD__, '`craft.blitz.getUri()` has been deprecated. Use `craft.blitz.fetchUri()` instead.');
 
         $params['no-cache'] = 1;
 


### PR DESCRIPTION
May save others a minute or two from looking this up in docs.