### PR TITLE
Fix deprecation message

### DIFF
--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -116,7 +116,7 @@ class BlitzVariable
      */
     public function getUri(string $uri, array $params = []): Markup
     {
-        Craft::$app->getDeprecator()->log(__METHOD__, '`craft.blitz.getUri()` has been deprecated. Use `craft.blitz.fetch()` instead.');
+        Craft::$app->getDeprecator()->log(__METHOD__, '`craft.blitz.getUri()` has been deprecated. Use `craft.blitz.fetchUri()` instead.');
 
         $params['no-cache'] = 1;
 


### PR DESCRIPTION
A person with dusty old templates calling `craft.blitz.getUri()` will encounter this deprecation message in the control panel:

<img width="350" alt="Screen Shot 2023-06-28 at 12 32 55 PM@2x" src="https://github.com/putyourlightson/craft-blitz/assets/2488775/c43578f7-fcbe-45c5-ada5-99a2ffb954ce">

And if this misguided adventurer does indeed replace it with `craft.blitz.fetch()` and bother testing it, he’ll discover no such method exists.

The docblock is already correct, and this PR fixes the deprecation warning to recommend `craft.blitz.fetchUri()` instead.