### PR TITLE
Caddy SSI Support

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -134,6 +134,9 @@ return [
         // With this setting enabled, Blitz will statically include templates using Server-Side Includes (SSI), which must be enabled on the web server.
         //'ssiEnabled' => false,
 
+        // With this setting enabled, Blitz will output "SSI" tags in the Caddy Server Templates syntax; this is not compatible with nGinx or Apache's standard SSI syntax. This should only be set to true if you are running Caddy Server
+        //'caddySSI' => false,
+
         // With this setting enabled, Blitz will statically include templates using Edge-Side Includes (ESI), which must be enabled on the web server or CDN.
         //'esiEnabled' => false,
 

--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -203,6 +203,11 @@ class SettingsModel extends Model
     public bool $ssiEnabled = false;
 
     /**
+     * With this setting enabled, Blitz will output "SSI" tags in the Caddy Server Templates syntax; this is not compatible with nGinx or Apache's standard SSI syntax. This should only be set to true if you are running Caddy Server.
+     */
+    public bool $caddySSI = false;
+
+    /**
      * With this setting enabled, Blitz will fetch cached includes using Edge-Side Includes (ESI), which must be enabled on the server.
      */
     public bool $esiEnabled = false;

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -338,6 +338,16 @@
             on: settings.ssiEnabled,
             fieldClass: 'width-50',
         }) }}
+        {{ forms.lightswitchField({
+            id: 'caddySSI',
+            label: "Use Caddy Server Templates syntax instead of SSI syntax"|t('blitz'),
+            instructions: instructions("Only enable this if you are running Caddy Server."|t('blitz'), info),
+            tip: '...',
+            warning: config.caddySSI is defined ? configWarning('caddySSI'),
+            name: 'settings[caddySSI]',
+            on: settings.caddySSI,
+            fieldClass: 'width-50',
+        }) }}
 
         <!--#include virtual="{{ detectSsiActionUrl }}" -->
         <script>

--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -225,7 +225,12 @@ class BlitzVariable
         Blitz::$plugin->generateCache->addSsiInclude($includeId);
         $uri = $this->_getUriWithParams($uri, $params);
 
-        return Template::raw('<!--#include virtual="' . $uri . '" -->');
+        if (Blitz::$plugin->settings->caddySSI) {
+            return Template::raw('{{httpInclude "' . $uri . '" }}');
+        }
+        else {
+            return Template::raw('<!--#include virtual="' . $uri . '" -->');
+        }
     }
 
     /**

--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -226,7 +226,7 @@ class BlitzVariable
         $uri = $this->_getUriWithParams($uri, $params);
 
         if (Blitz::$plugin->settings->caddySSI) {
-            return Template::raw('{{httpInclude "' . $uri . '" }}');
+            return Template::raw('<!--#caddy httpInclude "' . $uri . '" -->');
         }
         else {
             return Template::raw('<!--#include virtual="' . $uri . '" -->');


### PR DESCRIPTION
Hi Ben,

This appears to be working correctly with our Caddy Server, so thought I'd put this forward as a potential change to merge in. Completely understand if you'd rather not.

To get this to work I've added a new Setting so that Blitz is aware that the server is Caddy rather than Apache/nginx. When this is the case the syntax for the SSI output changes from:

`<!--#include virtual= ... -->`

to

`<!--#caddy httpInclude ... -->`

This is all that was needed in the Blitz plugin itself.

To get this to work in Caddy, it must be configured to look for those delimiters rather than the standard Caddy ones (`{{` and `}}`).

This is a fully working Caddyfile that does this;

```
# Snippets (see: https://caddyserver.com/docs/caddyfile/concepts)
(staticFileCache) {
        @static {
                file
                path *.ico *.css *.js *.gif *.jpg *.jpeg *.webp *.png *.svg *.woff2
        }
        header @static Cache-Control max-age=5184000
}

(blitzNoQueryString) {
        @blitzCache {
                method GET
                not expression {query} != ''
        }
        route @blitzCache {
                try_files /cache/blitz/{host}{uri}/index.html {path} {path}/index.php?{query}
        }
}

(wordpressBruteForce) {
        @block1 {
                path /wp-*
        }
        abort @block1

        @block2 {
                path *wp-includes*
        }
        abort @block2
}

blitz-caddy.viewcreative.agency {
        root * /websites/blitz-caddy/web
        encode gzip zstd

        file_server

        import staticFileCache
        import blitzNoQueryString
        import wordpressBruteForce

        templates {
                between <!--#caddy -->
        }

        log {
                output file /websites/_logs/blitz-caddy.log
        }

        php_fastcgi unix//run/php/php8.1-fpm.sock
}
```

The part that's relevant to the SSI is just this:

```
        templates {
                between <!--#caddy -->
        }
```

This causes Caddy to use its Template middleware, and to look for those specific delimiters for Template commands.

You can see a working example of this at the following URL:
https://blitz-caddy.viewcreative.agency/

The _layout.twig includes:
```
{{ craft.blitz.includeCached('_partials/cachedInclude.twig') }}
```

And the content of `_partials/cachedInclude.twig` is just a string:
```
This is a cached include that should be being loaded via SSI
```

Please let me know if there's any sort of further testing I ought to do.