### PR TITLE
Run inject script once per view

### DIFF
--- a/src/resources/js/blitzInjectScript.js
+++ b/src/resources/js/blitzInjectScript.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-document.addEventListener('{injectScriptEvent}', injectElements);
+document.addEventListener('{injectScriptEvent}', injectElements, { once: true });
 function injectElements() {
     return __awaiter(this, void 0, void 0, function* () {
         if (!document.dispatchEvent(new CustomEvent('beforeBlitzInjectAll', {

--- a/src/resources/js/blitzInjectScript.ts
+++ b/src/resources/js/blitzInjectScript.ts
@@ -1,5 +1,5 @@
 // The event name will be replaced with the `injectScriptEvent` config setting.
-document.addEventListener('{injectScriptEvent}', injectElements);
+document.addEventListener('{injectScriptEvent}', injectElements, { once: true });
 
 interface InjectElement {
     element: Element;


### PR DESCRIPTION
As far as I can tell, the inject script only needs to run when it comes up anyway - it will not fire a second time in the same page.