### PR TITLE
Replace `polyfill.io` with Cloudflare mirror for Craft 3.x

### DIFF
--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -188,9 +188,9 @@ class BlitzVariable
             }
         }
 
-        // Create polyfills using https://polyfill.io/v3/url-builder/.
+        // Create polyfills using Cloudflare mirror of polyfill.io: https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk
         $polyfills = ['fetch', 'Promise', 'CustomEvent'];
-        $polyfillUrl = 'https://polyfill.io/v3/polyfill.min.js?features='.implode('%2C', $polyfills);
+        $polyfillUrl = 'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features='.implode('%2C', $polyfills);
 
         // Register polyfills for IE11 only, using the `module/nomodule` pattern.
         // https://3perf.com/blog/polyfills/#modulenomodule


### PR DESCRIPTION
Due to a supply chain attack affecting `polyfill.io`, this replaces references to the now compromised library with one hosted by Cloudflare for the Craft 3.x version of the plugin.

More info:
 - https://sansec.io/research/polyfill-supply-chain-attack
 - https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk