### PR TITLE
only refresh variants after order complete if their inventory is tracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 
 - The `craft.blitz.csrfInput()`, `craft.blitz.csrfParam()` and `craft.blitz.csrfToken()` functions now output inline values rather than inject scripts when called via AJAX requests.
+- The `CommerceIntegration` now only refreshes the variants if their inventory is tracked
 
 ## 5.5.1 - 2024-07-23
 

--- a/src/drivers/integrations/CommerceIntegration.php
+++ b/src/drivers/integrations/CommerceIntegration.php
@@ -38,7 +38,7 @@ class CommerceIntegration extends BaseIntegration
                 $order = $event->sender;
                 foreach ($order->getLineItems() as $lineItem) {
                     $purchasable = $lineItem->getPurchasable();
-                    if ($purchasable instanceof Variant) {
+                    if ($purchasable instanceof Variant && $purchasable->inventoryTracked) {
                         Blitz::$plugin->refreshCache->addElement($purchasable);
                     }
                 }


### PR DESCRIPTION
This PR updates the `CommerceIntegration` to check if the variant that is bought also has his inventory tracked before refreshing the cache