### PR TITLE
Fixed “Identifier 'injectScriptEvent' has already been declared”

### DIFF
--- a/src/resources/js/blitzInjectScript.js
+++ b/src/resources/js/blitzInjectScript.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const injectScriptEvent = '{injectScriptEvent}';
+var injectScriptEvent = '{injectScriptEvent}';
 if (injectScriptEvent === 'load') {
     window.addEventListener('load', injectElements, { once: true });
 }

--- a/src/resources/js/blitzInjectScript.ts
+++ b/src/resources/js/blitzInjectScript.ts
@@ -1,5 +1,5 @@
 // The event name will be replaced with the `injectScriptEvent` config setting.
-const injectScriptEvent = '{injectScriptEvent}';
+var injectScriptEvent = '{injectScriptEvent}';
 // @ts-ignore
 if (injectScriptEvent === 'load') {
     window.addEventListener('load', injectElements, {once: true});


### PR DESCRIPTION
Fixes https://github.com/boboldehampsink/craft-blitz/commit/a7b7e6cc1a03b0c42e1a18e515f0f34bc705d002#commitcomment-150019921