### PR TITLE
Add `refreshExpiredCacheAfterVisit` config setting

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -200,6 +200,9 @@ return [
         // Whether the cache should be refreshed when an element is saved but not live.
         //'refreshCacheWhenElementSavedNotLive' => false,
 
+        // Whether expired cached pages should be refreshed after being visited by a user.
+        //'refreshExpiredCacheAfterVisit' => true,
+
         // Whether non-HTML responses should be cached. With this setting enabled, Blitz will also cache pages that return non-HTML responses. If enabled, you should ensure that URIs that should not be cached, such as API endpoints, XML sitemaps, etc. are added as excluded URI patterns.
         //'cacheNonHtmlResponses' => false,
 

--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -335,6 +335,11 @@ class SettingsModel extends Model
     public bool $refreshCacheWhenElementSavedNotLive = false;
 
     /**
+     * Whether expired cached pages should be refreshed after being visited by a user.
+     */
+    public bool $refreshExpiredCacheAfterVisit = true;
+
+    /**
      * Whether non-HTML responses should be cached.
      */
     public bool $cacheNonHtmlResponses = false;

--- a/src/services/CacheRequestService.php
+++ b/src/services/CacheRequestService.php
@@ -682,7 +682,9 @@ class CacheRequestService extends Component
 
         $cacheControlHeader = Blitz::$plugin->settings->cacheControlHeader;
 
-        if (Blitz::$plugin->expireCache->getIsExpiredSiteUri($siteUri)) {
+        if (Blitz::$plugin->settings->refreshExpiredCacheAfterVisit
+            && Blitz::$plugin->expireCache->getIsExpiredSiteUri($siteUri)
+        ) {
             $cacheControlHeader = Blitz::$plugin->settings->cacheControlHeaderExpired;
             Blitz::$plugin->refreshCache->refreshExpiredSiteUris([$siteUri]);
             Blitz::$plugin->refreshCache->refresh();


### PR DESCRIPTION
Adds a `refreshExpiredCacheAfterVisit` config setting that determines whether expired cached pages should be refreshed after being visited by a user.