### PR TITLE
Use the correct site when generating the CSRF action uri

### DIFF
--- a/src/variables/BlitzVariable.php
+++ b/src/variables/BlitzVariable.php
@@ -259,6 +259,7 @@ class BlitzVariable
         }
 
         $uri = UrlHelper::actionUrl('blitz/csrf/json', null, null, false);
+        $uri = UrlHelper::siteUrl(UrlHelper::rootRelativeUrl($uri));
         $config = new VariableConfigModel(['property' => $property]);
 
         return $this->getScript($uri, [], $config);


### PR DESCRIPTION
On a multi-site setup, where sites use different domains, if the `csrfInput` variable is used on a site that's on a different domain to the default site, we can get CORS errors:

```
Access to fetch at 'https://site-a.ddev.site/actions/blitz/csrf/json' from origin 'https://site-b.ddev.site' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This change generates the csrf token URI similar to how dynamic includes URIs are generated: `"https://site-b.ddev.site/actions/blitz/csrf/json"`