### PR TITLE
 Add limits to Cloudflare purge requests, to prevent 429 Too Many Requests

### DIFF
--- a/src/drivers/purgers/CloudflarePurger.php
+++ b/src/drivers/purgers/CloudflarePurger.php
@@ -36,6 +36,13 @@ class CloudflarePurger extends BaseCachePurger
     public const API_URL_LIMIT = 100;
 
     /**
+     * @const The desired concurrency limit. Depending on Cloudflare plan, different settings
+     *        may work, but 6 is a safe default (3000/500 < 800/100).
+     * https://developers.cloudflare.com/cache/how-to/purge-cache/#availability-and-limits
+     */
+    public const CONCURRENCY_LIMIT = 6;
+
+    /**
      * @var string The API authentication method.
      */
     public string $authenticationMethod = 'apiToken';
@@ -251,8 +258,10 @@ class CloudflarePurger extends BaseCachePurger
 
         // Create a pool of requests
         $pool = new Pool($client, $requests, [
+            'concurrency' => self::CONCURRENCY_LIMIT,
             'fulfilled' => function() use (&$response) {
                 $response = true;
+                usleep(150_000);
             },
             'rejected' => function($reason) {
                 if ($reason instanceof RequestException) {

--- a/src/drivers/purgers/CloudflarePurger.php
+++ b/src/drivers/purgers/CloudflarePurger.php
@@ -261,7 +261,7 @@ class CloudflarePurger extends BaseCachePurger
             'concurrency' => self::CONCURRENCY_LIMIT,
             'fulfilled' => function() use (&$response) {
                 $response = true;
-                usleep(150_000);
+                usleep(15_000);
             },
             'rejected' => function($reason) {
                 if ($reason instanceof RequestException) {


### PR DESCRIPTION
Addresses #341 and #296, as well as a problem I'm _regularly_ seeing for myself maintaining a larger site running Blitz:

```
/storage/logs$ cat blitz-2026-03-09.log
[2026-03-09 00:05:02] Expired Blitz cache successfully refreshed. [via console command by "www-data"]
[2026-03-09 00:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 00:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:02] Expired Blitz cache successfully refreshed. [via console command by "www-data"]
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 01:05:06] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 02:05:02] Expired Blitz cache successfully refreshed. [via console command by "www-data"]
[2026-03-09 02:05:07] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 02:05:07] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[2026-03-09 02:05:07] Client error: `DELETE https://api.cloudflare.com/client/v4/zones/ZONE_ID/purge_cache` resulted in a `429 Too Many Requests` response
[...]
```

https://github.com/putyourlightson/craft-blitz/issues/341#issuecomment-900925868 is correct to identify the broader Cloudflare rate limits, but misses that the single-file cache purge API used by Blitz for purging actually has [its own separate, more restrictive rate limits](https://developers.cloudflare.com/cache/how-to/purge-cache/#single-file-purge-limits): at time of writing, those are


|                             | Free                 | Pro                   | Business              | Enterprise            |
|-----------------------------|----------------------|-----------------------|-----------------------|-----------------------|
| URLs                        | 800 URLs per second  | 1500 URLs per second  | 1500 URLs per second  | 3000 URLs per second  |
| Max operations per request  | 100                  | 100                   | 100                   | 500                   |
| ∴ Requests per second (applying Blitz's batching into 100s) | 8 rps | 15 rps | 15 rps   | 30 rps     |

[Guzzle's whole Pool architecture](https://github.com/guzzle/guzzle/blob/7.10/src/Pool.php) is based around the [EachPromise](https://github.com/guzzle/promises/blob/2.3/src/EachPromise.php), which doesn't support a rate limit, but does support a concurrency limit. Conveniently, the enterprise plan theoretical limit if you were using a batch size of 500 rather than 100 (of 6rps) is below the free plan theoretical limit (of 8rps), and I'm therefore proposing it's reasonable to initially set concurrency to that. An improvement on this PR might be to allow a user to configure this, but the situation currently is that [the Guzzle default Pool concurrency of 25](https://github.com/guzzle/guzzle/blob/7.10/src/Pool.php#L43-L45) is used, which guarantees that, for any user not on an Enterprise plan, there is a risk of being rate-limited. The conservative threshold used here should help to ameliorate that risk.

[The methodology Cloudflare uses for these rate limits is token bucketing with linear refill](https://developers.cloudflare.com/cache/how-to/purge-cache/#token-bucket-rate-limiting), which allows for burst requests, but means it's not an exact science as to how many requests will be allowed. For that reason, I've also included a small 15ms delay between each subsequent request (this works because [eachPromise runs onFulfilled synchronously](https://github.com/guzzle/promises/blob/2.3/src/EachPromise.php#L172-L179)). As was rightly pointed out in https://github.com/putyourlightson/craft-blitz/issues/341#issuecomment-900925868, stalling the queue with retries isn't a good solution here, so I think this might be a reasonable middle ground; as imprecise as it is, it's likely to be an improvement on the risk of rate-limiting that's currently present.

In terms of the extent to which this will delay the purge process, it should be relatively limited. Modelling an API request to Cloudflare as taking a very conservative 100ms all-included, we'd get the times below:

| **Number of URLs to purge**                                                                                             | **600** | **6,000** | **60,000** | **600,000** |
|-------------------------------------------------------------------------------------------------------------------------|---------|-----------|------------|-------------|
| **Time to complete in the current model (assuming all requests were successful)**                                       | ~100ms  | ~240ms    | ~2400ms    | ~24000ms    |
| **Number of URLs that would currently get purged (ideally, assuming Pro plan limits and ignoring token bucketing)**     | 600     | 1500      | 3000       | 36000       |
| **Percentage of URLs that would currently get purged (ideally, assuming Pro plan limits and ignoring token bucketing)** | 100%    | 25%       | 5%         | 6%          |
| **Time to complete with all URLs (ideally, still not guaranteed) _actually_ getting purged with this patch**                                            | ~100ms  | ~1900ms   | ~19000ms   | ~190000ms   |