### PR TITLE
Exclude expired/invalid token URLs from caching

### DIFF
--- a/src/services/CacheRequestService.php
+++ b/src/services/CacheRequestService.php
@@ -422,8 +422,19 @@ class CacheRequestService extends Component
             return true;
         }
 
+        // Detect the presence of a token, rather than a resolved one, so that
+        // expired or invalid tokens are also excluded from being cached.
+        // `Request::getToken()` returns null once a token has expired or can’t
+        // be resolved, which would otherwise leave the URL cacheable.
+        // https://github.com/putyourlightson/craft-blitz/issues/898
+        $tokenParam = Craft::$app->getConfig()->getGeneral()->tokenParam;
+
         if (
-            ($request->getSiteToken() !== null || $request->getToken() !== null)
+            (
+                $request->getSiteToken() !== null
+                || $request->getQueryParam($tokenParam) !== null
+                || $request->getHeaders()->get('X-Craft-Token') !== null
+            )
             && !$this->getIsGeneratorRequest()
         ) {
             return true;

--- a/src/services/CacheRequestService.php
+++ b/src/services/CacheRequestService.php
@@ -422,10 +422,14 @@ class CacheRequestService extends Component
             return true;
         }
 
-        // Detect the presence of a token, rather than a resolved one, so that
-        // expired or invalid tokens are also excluded from being cached.
+        // Detect the *presence* of a token rather than a resolved one, so that
+        // expired or invalid tokens are also excluded from being cached —
         // `Request::getToken()` returns null once a token has expired or can’t
         // be resolved, which would otherwise leave the URL cacheable.
+        // The token can arrive as a site token, the query-string param, or an
+        // `X-Craft-Token` header (the same sources `Request::getToken()` reads),
+        // so all three are checked. This is intentionally not preview-mode
+        // detection, which is handled above and is itself validity-dependent.
         // https://github.com/putyourlightson/craft-blitz/issues/898
         $tokenParam = Craft::$app->getConfig()->getGeneral()->tokenParam;
 


### PR DESCRIPTION
Fixes #898.

`getIsPreviewOrTokenRequest()` decides a request is a token request via `Request::getToken()`. Craft's `getToken()` returns `null` once a preview/share token has expired or can't be resolved to a token route, so an expired token URL is not detected as a token request. Since the token param is also stripped from the cache key, the URL is then cached as the base page and served with the configured (long-lived) `cacheControlHeader` — so shared caches / CDNs cache the tokenized URL and it can be served to other users and indexed.

This changes the check to detect the **presence** of the token param (query param + `X-Craft-Token` header) rather than a resolved token, so expired/invalid token URLs stay out of the cache. `getSiteToken()` is already presence-based, and the existing `!getIsGeneratorRequest()` guard keeps cache generation working (generator requests carry a valid token resolving to `blitz/generator/generate`).

Reproduction and analysis are in #898.
