### PR TITLE
Use configured token param when generating urls.

### DIFF
--- a/src/drivers/generators/BaseCacheGenerator.php
+++ b/src/drivers/generators/BaseCacheGenerator.php
@@ -179,7 +179,8 @@ abstract class BaseCacheGenerator extends SavableComponent implements CacheGener
         $params = [];
 
         if ($withToken) {
-            $params['token'] = Craft::$app->getTokens()->createToken(self::GENERATE_ACTION_ROUTE);
+            $tokenParam = Craft::$app->getConfig()->getGeneral()->tokenParam;
+            $params[$tokenParam] = Craft::$app->getTokens()->createToken(self::GENERATE_ACTION_ROUTE);
         }
 
         foreach ($siteUris as $siteUri) {


### PR DESCRIPTION
This resolves a bug in a very specific scenario.

- local generator
- alternate token name, e.g. `cmstoken`
- expire cache + regenerate in a queue
- cache query string as unique pages

We found this created an infinite loop where the generator would attempt to render a page but receives an already cached page. The application not knowing it's triggered by a generator (by not matching the token) also triggers the refresh job (in `CacheRequestService::prepareResponse()`). Which then a new generate job renders from cache again (yada yada yada it's a loop).

The other quirk of this bug is that the HTML body of the cached result is dumped into the queue runner stdout. This also happens in the `refresh-expired` CLI route used in cron jobs. This mean one of our servers filled up with 50gb of logs overnight and locked up. We're never quite figured out the mechanism of how the stdout breaks out from the amphp process wrapper but this patch certainly fixes the overall behaviour.