### PR TITLE
fix(slug): If page slug changes, always clear cache on the old slug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Disabled foreign key checks when inserting element caches to help prevent deadlocks when elements are saved ([#903](https://github.com/putyourlightson/craft-blitz/issues/903)).
 - Fixed a bug in which the configured token param name was not being respected when generating URLs ([#902](https://github.com/putyourlightson/craft-blitz/issues/902)).
+- Fixed a bug in which changing an element’s slug/URI left the previous URI cached and still available on the frontend.
 
 ## 5.12.10 - 2026-06-30
 

--- a/src/behaviors/ElementChangedBehavior.php
+++ b/src/behaviors/ElementChangedBehavior.php
@@ -21,6 +21,7 @@ use yii\base\Behavior;
  * @property-read bool $hasChanged
  * @property-read bool $hasBeenDeleted
  * @property-read bool $hasStatusChanged
+ * @property-read bool $hasUriChanged
  * @property-read bool $hasAssetFileChanged
  * @property-read bool $hasRefreshableStatus
  */
@@ -97,6 +98,21 @@ class ElementChangedBehavior extends Behavior
         $this->changedAttributes = $this->getChangedAttributes();
         $this->changedFieldsHandles = $this->getChangedFieldHandles();
 
+        // Detect URI/slug changes even when dirty attributes have already been reset
+        // (for example after Craft’s updateSlugAndUri flow).
+        if ($this->getHasUriChanged()) {
+            if (!in_array('uri', $this->changedAttributes, true)) {
+                $this->changedAttributes[] = 'uri';
+            }
+            if (
+                $this->originalElement !== null
+                && $element->slug !== $this->originalElement->slug
+                && !in_array('slug', $this->changedAttributes, true)
+            ) {
+                $this->changedAttributes[] = 'slug';
+            }
+        }
+
         if ($element->firstSave) {
             return true;
         }
@@ -106,6 +122,12 @@ class ElementChangedBehavior extends Behavior
         }
 
         if ($this->getHasStatusChanged()) {
+            return true;
+        }
+
+        if ($this->getHasUriChanged()) {
+            $this->isChangedByAttributes = true;
+
             return true;
         }
 
@@ -138,6 +160,22 @@ class ElementChangedBehavior extends Behavior
         $element = $this->owner;
 
         return $element->dateDeleted !== null;
+    }
+
+    /**
+     * Returns whether the element’s URI has changed.
+     *
+     * @since 5.12.11
+     */
+    public function getHasUriChanged(): bool
+    {
+        $element = $this->owner;
+
+        if ($this->originalElement === null) {
+            return false;
+        }
+
+        return $element->uri !== $this->originalElement->uri;
     }
 
     /**

--- a/src/jobs/RefreshCacheJob.php
+++ b/src/jobs/RefreshCacheJob.php
@@ -60,6 +60,10 @@ class RefreshCacheJob extends BaseJob implements RetryableJobInterface
     {
         $refreshData = RefreshDataModel::createFromData($this->data);
 
+        // Always remove previous element URIs (slug/URI changes), regardless of refresh mode.
+        // Otherwise File Storage + server rewrites can keep serving the old path forever.
+        $this->clearPreviousSiteUris($refreshData);
+
         $this->populateCacheIdsFromElementCaches($refreshData);
 
         // Clear the site URIs early.
@@ -100,6 +104,22 @@ class RefreshCacheJob extends BaseJob implements RetryableJobInterface
     protected function defaultDescription(): string
     {
         return Craft::t('blitz', 'Refreshing Blitz cache');
+    }
+
+    /**
+     * Clears, flushes and purges previous site URIs after element URI changes.
+     */
+    private function clearPreviousSiteUris(RefreshDataModel $refreshData): void
+    {
+        $previousSiteUris = $refreshData->getPreviousSiteUris();
+
+        if (empty($previousSiteUris)) {
+            return;
+        }
+
+        Blitz::$plugin->clearCache->clearUris($previousSiteUris);
+        Blitz::$plugin->flushCache->flushUris($previousSiteUris);
+        Blitz::$plugin->cachePurger->purgeUris($previousSiteUris);
     }
 
     /**

--- a/src/models/RefreshDataModel.php
+++ b/src/models/RefreshDataModel.php
@@ -16,6 +16,7 @@ use putyourlightson\blitz\helpers\FieldHelper;
  * request.
  *
  * @property-read int[] $cacheIds
+ * @property-read SiteUriModel[] $previousSiteUris
  * @property-read array $elementTypes
  * @property-read int[] $assetsChangedByFile
  * @property-read int[] $assetsChangedByImage
@@ -27,6 +28,7 @@ class RefreshDataModel extends BaseDataModel
     /**
      * @var array{
      *          cacheIds: array<int, int[]|bool>,
+     *          previousSiteUris: array<int, array<string, bool>>,
      *          elements: array<string, array{
      *              sourceIds: array<int, bool>,
      *              elementIds: array<int, bool>,
@@ -40,6 +42,7 @@ class RefreshDataModel extends BaseDataModel
      */
     public array $data = [
         'cacheIds' => [],
+        'previousSiteUris' => [],
         'elements' => [],
     ];
 
@@ -62,6 +65,28 @@ class RefreshDataModel extends BaseDataModel
     public function getCacheIds(): array
     {
         return $this->getKeysAsValues(['cacheIds']);
+    }
+
+    /**
+     * Returns previous site URIs that must be removed after an element URI change.
+     *
+     * @return SiteUriModel[]
+     * @since 5.12.11
+     */
+    public function getPreviousSiteUris(): array
+    {
+        $siteUris = [];
+
+        foreach ($this->data['previousSiteUris'] ?? [] as $siteId => $uris) {
+            foreach (array_keys($uris) as $uri) {
+                $siteUris[] = new SiteUriModel([
+                    'siteId' => $siteId,
+                    'uri' => $uri,
+                ]);
+            }
+        }
+
+        return $siteUris;
     }
 
     /**
@@ -160,6 +185,16 @@ class RefreshDataModel extends BaseDataModel
         }
     }
 
+    /**
+     * Adds a previous site URI to be cleared after a URI change.
+     *
+     * @since 5.12.11
+     */
+    public function addPreviousSiteUri(int $siteId, string $uri): void
+    {
+        $this->data['previousSiteUris'][$siteId][$uri] = true;
+    }
+
     public function addSourceId(string $elementType, int $sourceId): void
     {
         $this->data['elements'][$elementType]['sourceIds'][$sourceId] = true;
@@ -195,6 +230,17 @@ class RefreshDataModel extends BaseDataModel
             $this->addIsChangedByAttributes($element, $elementChanged->isChangedByAttributes);
             $this->addIsChangedByFields($element, $elementChanged->isChangedByFields);
             $this->addIsChangedByAssetFile($element, $elementChanged->isChangedByAssetFile);
+
+            if (
+                $elementChanged->getHasUriChanged()
+                && $elementChanged->originalElement !== null
+                && $elementChanged->originalElement->uri !== null
+            ) {
+                $this->addPreviousSiteUri(
+                    $elementChanged->originalElement->siteId,
+                    $elementChanged->originalElement->uri,
+                );
+            }
         }
     }
 

--- a/tests/Feature/RefreshCacheTest.php
+++ b/tests/Feature/RefreshCacheTest.php
@@ -8,7 +8,10 @@ use craft\elements\Asset;
 use craft\elements\Entry;
 use putyourlightson\blitz\Blitz;
 use putyourlightson\blitz\helpers\RefreshCacheHelper;
+use putyourlightson\blitz\jobs\RefreshCacheJob;
 use putyourlightson\blitz\models\RefreshDataModel;
+use putyourlightson\blitz\models\SettingsModel;
+use putyourlightson\blitz\records\CacheRecord;
 use putyourlightson\blitz\records\ElementQueryRecord;
 use putyourlightson\blitz\records\ElementQuerySourceRecord;
 
@@ -104,6 +107,53 @@ test('Element is tracked when its attribute is changed', function() {
             changedBy: 'attributes',
             changedAttributes: ['title'],
         );
+});
+
+test('Element is tracked with its previous site URI when its URI is changed', function() {
+    $entry = createEntry();
+    $previousUri = $entry->uri;
+    $entry->uri = 'new-page-uri';
+    Blitz::$plugin->refreshCache->addElement($entry);
+
+    $refreshData = Blitz::$plugin->refreshCache->refreshData;
+    $previousSiteUris = $refreshData->getPreviousSiteUris();
+
+    expect($refreshData->getElementIds(Entry::class))
+        ->toEqual([$entry->id])
+        ->and($refreshData->getChangedAttributes(Entry::class, $entry->id))
+        ->toContain('uri')
+        ->and($previousSiteUris)
+        ->toHaveCount(1)
+        ->and($previousSiteUris[0]->siteId)
+        ->toEqual($entry->siteId)
+        ->and($previousSiteUris[0]->uri)
+        ->toEqual($previousUri);
+});
+
+test('Cached previous site URI is cleared when an element URI is changed', function() {
+    $entry = createEntry();
+    $previousSiteUri = createSiteUri(siteId: $entry->siteId, uri: $entry->uri);
+    Blitz::$plugin->generateCache->addElement($entry);
+    Blitz::$plugin->generateCache->save(createOutput(), $previousSiteUri);
+    Blitz::$plugin->settings->refreshMode = SettingsModel::REFRESH_MODE_EXPIRE;
+
+    expect(Blitz::$plugin->cacheStorage->get($previousSiteUri))
+        ->not->toBeEmpty()
+        ->and(CacheRecord::find()->where($previousSiteUri->toArray())->count())
+        ->toBe(1);
+
+    $entry->uri = 'new-page-uri';
+    Blitz::$plugin->refreshCache->addElement($entry);
+
+    $job = new RefreshCacheJob([
+        'data' => Blitz::$plugin->refreshCache->refreshData->data,
+    ]);
+    $job->execute(Craft::$app->getQueue());
+
+    expect(Blitz::$plugin->cacheStorage->get($previousSiteUri))
+        ->toBeEmpty()
+        ->and(CacheRecord::find()->where($previousSiteUri->toArray())->count())
+        ->toBe(0);
 });
 
 test('Element is tracked when its field is changed', function() {


### PR DESCRIPTION
When you change the slug of an entry, cache isn't clear on the old slug, leaving the old url still active.

Fixes #905 

Fixes applied:

On URI change, Blitz now:

1. Detects the change via ElementChangedBehavior (compares against the original element, even if dirty attributes were already cleared)
2. Tracks the previous site URI in refresh data
3. Always clears, flushes, and purges that previous URI in RefreshCacheJob—regardless of refresh mode—so the old path can’t keep being served